### PR TITLE
Support selection of ethereum network and change prod default to mainnet

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -72,11 +72,16 @@ function add_menus() {
 }
 add_action( 'admin_menu', __NAMESPACE__ . '\add_menus' );
 
+/**
+ * Add FAQ link to plugin menu.
+ */
 function add_faq_link() {
+	// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- can't find any other way to get external link submenu except redirect headers or crazy url filter shit
 	global $submenu;
-	$submenu[TOP_LEVEL_MENU][] = array('FAQ and Help', 'edit_posts', "https://cvlconsensys.zendesk.com/hc/en-us/categories/360001000232-Journalists");
+	$submenu[ TOP_LEVEL_MENU ][] = array( 'FAQ and Help', 'edit_posts', 'https://cvlconsensys.zendesk.com/hc/en-us/categories/360001000232-Journalists' );
+	// phpcs:enable
 }
-add_action('admin_menu', __NAMESPACE__ . '\add_faq_link');
+add_action( 'admin_menu', __NAMESPACE__ . '\add_faq_link' );
 
 /**
  * Civil Newsroom Management page content.

--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -32,7 +32,10 @@ export enum siteOptionKeys {
 }
 
 export const NETWORK_NAME = window.civilNamespace.networkName || (window.civilNamespace.wpDebug ? "rinkeby" : "main");
-export const NETWORK_NICE_NAME = NETWORK_NAME === "main" ? "Main Ethereum Network" : (NETWORK_NAME[0].toUpperCase() + NETWORK_NAME.substr(1) + " Test Network");
+export const NETWORK_NICE_NAME =
+  NETWORK_NAME === "main"
+    ? "Main Ethereum Network"
+    : NETWORK_NAME[0].toUpperCase() + NETWORK_NAME.substr(1) + " Test Network";
 if (NETWORK_NAME !== "main") {
   urls.ETHERSCAN_DOMAIN = `${NETWORK_NAME}.etherscan.io`;
 }

--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -7,6 +7,7 @@ export const urls = {
   HELP_BASE: "https://cvlconsensys.zendesk.com/hc/en-us/",
   FAQ_HOME: "https://cvlconsensys.zendesk.com/hc/en-us/categories/360001000232-Journalists",
   NEWSROOM_MANAGER: "/wp-admin/admin.php?page=civil-newsroom-protocol-management",
+  ETHERSCAN_DOMAIN: "etherscan.io",
 };
 
 export enum postMetaKeys {
@@ -32,6 +33,9 @@ export enum siteOptionKeys {
 
 export const NETWORK_NAME = window.civilNamespace.networkName || "main";
 export const NETWORK_NICE_NAME = NETWORK_NAME === "main" ? "Main Ethereum Network" : (NETWORK_NAME[0].toUpperCase() + NETWORK_NAME.substr(1) + " Test Network");
+if (NETWORK_NAME !== "main") {
+  urls.ETHERSCAN_DOMAIN = `${NETWORK_NAME}.etherscan.io`;
+}
 
 export const theme = {
   primaryButtonBackground: "#0085ba",

--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -31,7 +31,7 @@ export enum siteOptionKeys {
   NEWSROOM_CHARTER = "civil_newsroom_protocol_newsroom_charter",
 }
 
-export const NETWORK_NAME = window.civilNamespace.networkName || "main";
+export const NETWORK_NAME = window.civilNamespace.networkName || (window.civilNamespace.wpDebug ? "rinkeby" : "main");
 export const NETWORK_NICE_NAME = NETWORK_NAME === "main" ? "Main Ethereum Network" : (NETWORK_NAME[0].toUpperCase() + NETWORK_NAME.substr(1) + " Test Network");
 if (NETWORK_NAME !== "main") {
   urls.ETHERSCAN_DOMAIN = `${NETWORK_NAME}.etherscan.io`;

--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -30,8 +30,8 @@ export enum siteOptionKeys {
   NEWSROOM_CHARTER = "civil_newsroom_protocol_newsroom_charter",
 }
 
-export const NETWORK_NAME = "rinkeby";
-export const NETWORK_NICE_NAME = "Rinkeby Test Network";
+export const NETWORK_NAME = window.civilNamespace.networkName || "main";
+export const NETWORK_NICE_NAME = NETWORK_NAME === "main" ? "Main Ethereum Network" : (NETWORK_NAME[0].toUpperCase() + NETWORK_NAME.substr(1) + " Test Network");
 
 export const theme = {
   primaryButtonBackground: "#0085ba",

--- a/assets/newsroom-management/App.tsx
+++ b/assets/newsroom-management/App.tsx
@@ -44,9 +44,9 @@ class App extends React.Component<AppProps & DispatchProp<any>, AppState> {
   public async componentDidMount(): Promise<void> {
     if ((window as any).ethereum) {
       const metamaskEnabled = await (window as any).ethereum.isEnabled();
-      this.setState({metamaskEnabled});
+      this.setState({ metamaskEnabled });
     } else {
-      this.setState({metamaskEnabled: true});
+      this.setState({ metamaskEnabled: true });
     }
     if (!this.props.address && this.props.txHash && this.civil) {
       const newsroom = await this.civil.newsroomFromFactoryTxHashUntrusted(this.props.txHash);
@@ -107,7 +107,7 @@ class App extends React.Component<AppProps & DispatchProp<any>, AppState> {
             if ((window as any).ethereum) {
               await (window as any).ethereum.enable();
               console.log("here");
-              this.setState({metamaskEnabled: true});
+              this.setState({ metamaskEnabled: true });
             }
           }}
           profileAddressSaving={this.state.profileAddressSaving}

--- a/assets/post-panel/components/RevisionLinks.tsx
+++ b/assets/post-panel/components/RevisionLinks.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { BorderlessButton, ToolTip } from "@joincivil/components";
 import styled from "styled-components";
 import { siteTimezoneFormat } from "../../util";
+import { urls } from "../../constants";
 import { BodySection } from "../styles";
 
 export interface RevisionLinksProps {
@@ -36,7 +37,7 @@ export const RevisionLinks = (props: RevisionLinksProps): JSX.Element => {
   if (props.lastArchivedRevision) {
     let transactionArchive = (
       <Link
-        href={`https://rinkeby.etherscan.io/tx/${props.lastArchivedRevision.txHash}`}
+        href={`https://${urls.ETHERSCAN_DOMAIN}/tx/${props.lastArchivedRevision.txHash}`}
         disabled={!props.lastArchivedRevision.archive.transaction}
       >
         View on Ethereum{" "}
@@ -66,7 +67,7 @@ export const RevisionLinks = (props: RevisionLinksProps): JSX.Element => {
       <BodySection>
         <P>Index · {siteTimezoneFormat(props.lastPublishedRevision.published)}</P>
         <Link href={props.lastPublishedRevision.ipfsUrl}>View on IPFS</Link>
-        <Link href={`https://rinkeby.etherscan.io/tx/${props.lastPublishedRevision.txHash}`}>View on Ethereum</Link>
+        <Link href={`https://${urls.ETHERSCAN_DOMAIN}/tx/${props.lastPublishedRevision.txHash}`}>View on Ethereum</Link>
       </BodySection>
       {archiveSection}
     </div>

--- a/assets/util.tsx
+++ b/assets/util.tsx
@@ -10,7 +10,7 @@ const { dateI18n, getSettings } = window.wp.date;
 import { Civil, ApprovedRevision } from "@joincivil/core";
 import { Newsroom } from "@joincivil/core/build/src/contracts/newsroom";
 
-import { timestampFormat } from "./constants";
+import { timestampFormat, NETWORK_NAME } from "./constants";
 
 export const getCivil = (() => {
   const civil: Civil | undefined = hasInjectedProvider() ? new Civil() : undefined;
@@ -53,7 +53,7 @@ export async function getNewsroom(): Promise<Newsroom> {
 }
 
 export function isCorrectNetwork(networkName: string): boolean {
-  return networkName === "rinkeby"; // just hard code it for now
+  return networkName === NETWORK_NAME;
 }
 
 export function hasInjectedProvider(): boolean {

--- a/civil-newsroom.php
+++ b/civil-newsroom.php
@@ -35,6 +35,7 @@ define( __NAMESPACE__ . '\USER_NEWSROOM_ROLE_META_KEY', 'civil_newsroom_protocol
 define( __NAMESPACE__ . '\NEWSROOM_ADDRESS_OPTION_KEY', 'civil_newsroom_protocol_newsroom_address' );
 define( __NAMESPACE__ . '\NEWSROOM_TXHASH_OPTION_KEY', 'civil_newsroom_protocol_newsroom_txhash' );
 define( __NAMESPACE__ . '\NEWSROOM_CHARTER_OPTION_KEY', 'civil_newsroom_protocol_newsroom_charter' );
+define( __NAMESPACE__ . '\NETWORK_NAME_OPTION_KEY', 'civil_newsroom_protocol_network_name' );
 
 // Menus.
 define( __NAMESPACE__ . '\TOP_LEVEL_MENU', 'civil-newsroom-protocol-menu' );

--- a/custom-meta.php
+++ b/custom-meta.php
@@ -205,7 +205,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\newsroom_txhash_register_setting'
  * @return string Sanitized charter.
  */
 function sanitize_newsroom_charter( $input ) {
-	return json_decode(json_encode($input));
+	return json_decode( json_encode( $input ) );
 }
 
 /**
@@ -216,7 +216,7 @@ function newsroom_charter_register_setting() {
 		'general',
 		NEWSROOM_CHARTER_OPTION_KEY,
 		array(
-			'type' => 'string', // stringified JSON
+			'type' => 'string', // stringified JSON.
 			'single' => true,
 			'show_in_rest' => true,
 			'sanitize_callback' => __NAMESPACE__ . '\sanitize_newsroom_charter',

--- a/custom-meta.php
+++ b/custom-meta.php
@@ -317,7 +317,7 @@ function network_name_input() {
 		size="42"
 		id="<?php echo esc_attr( NETWORK_NAME_OPTION_KEY ); ?>"
 		name="<?php echo esc_attr( NETWORK_NAME_OPTION_KEY ); ?>"
-		placeholder="main"
+		placeholder="<?php echo esc_attr( WP_DEBUG ? 'rinkeby' : 'main' ); ?>"
 		value="<?php echo esc_attr( $value ); ?>"
 	/>
 	<p class="description"><code>"main" | "morden" | "ropsten" | "rinkeby" | "ganache"</code></p>

--- a/custom-meta.php
+++ b/custom-meta.php
@@ -152,8 +152,7 @@ function user_meta_callback( $user, $field_name ) {
 function newsroom_address_init() {
 	newsroom_address_register_setting();
 
-	// Just for debugging by superadmins - non-superadmins have to go through the dedicated Newsroom Management page.
-	if ( is_super_admin() ) {
+	if ( current_user_can( 'manage_options' ) ) {
 		add_settings_field(
 			NEWSROOM_ADDRESS_OPTION_KEY,
 			__( 'Newsroom Contract Address', 'civil' ),
@@ -239,6 +238,7 @@ function newsroom_address_input() {
 		placeholder="0x123abc"
 		value="<?php echo esc_attr( $value ); ?>"
 	/>
+	<p class="description"><strong>Warning:</strong> Don't change this unless you know what you're doing. Your newsroom should be set up via the <a href="<?php echo esc_url( menu_page_url( MANAGEMENT_PAGE, false ) ); ?>">Newsroom Manager</a> instead.</p>
 	<?php
 }
 
@@ -270,6 +270,58 @@ function sanitize_newsroom_address( $input ) {
 	}
 
 	return $addr;
+}
+
+/**
+ * Register and add network name field.
+ */
+function network_name_init() {
+	network_name_register_setting();
+
+	if ( current_user_can( 'manage_options' ) ) {
+		add_settings_field(
+			NETWORK_NAME_OPTION_KEY,
+			__( 'Ethereum Network Name', 'civil' ),
+			__NAMESPACE__ . '\network_name_input',
+			'general',
+			'default'
+		);
+	}
+}
+add_action( 'admin_init', __NAMESPACE__ . '\network_name_init' );
+
+/**
+ * Register network name setting.
+ */
+function network_name_register_setting() {
+	register_setting(
+		'general',
+		NETWORK_NAME_OPTION_KEY,
+		array(
+			'type'              => 'string',
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'sanitize_text_field',
+		)
+	);
+}
+add_action( 'rest_api_init', __NAMESPACE__ . '\network_name_register_setting' );
+
+/**
+ * Output form for capturing network name.
+ */
+function network_name_input() {
+	$value = get_option( NETWORK_NAME_OPTION_KEY );
+	?>
+	<input type="text"
+		size="42"
+		id="<?php echo esc_attr( NETWORK_NAME_OPTION_KEY ); ?>"
+		name="<?php echo esc_attr( NETWORK_NAME_OPTION_KEY ); ?>"
+		placeholder="main"
+		value="<?php echo esc_attr( $value ); ?>"
+	/>
+	<p class="description"><code>"main" | "morden" | "ropsten" | "rinkeby" | "ganache"</code></p>
+	<?php
 }
 
 /**

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -31,6 +31,7 @@ interface Window {
     wpAdminUrl: string;
     logoUrl?: string;
     adminEmail?: boolean;
+    networkName?: string;
   };
   civilImages: {
     metamask_confim_modal: string;

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -25,6 +25,7 @@ interface Window {
 
   web3: any;
   civilNamespace: {
+    wpDebug: boolean;
     newsroomAddress: string;
     newsroomTxHash: string;
     wpSiteUrl: string;

--- a/utils.php
+++ b/utils.php
@@ -135,6 +135,7 @@ function constants_script( $script_name ) {
 		'logoUrl' => get_site_icon_url(),
 		'adminEmail' => get_bloginfo( 'admin_email' ),
 		'newsroomTxHash' => get_option( NEWSROOM_TXHASH_OPTION_KEY ),
+		'networkName' => get_option( NETWORK_NAME_OPTION_KEY ),
 	] );
 
 	wp_add_inline_script( $script_name, "window.civilNamespace = $constants_json;" . PHP_EOL, 'before' );

--- a/utils.php
+++ b/utils.php
@@ -129,6 +129,7 @@ function common_scripts( $script_name ) {
  */
 function constants_script( $script_name ) {
 	$constants_json = json_encode( [
+		'wpDebug' => WP_DEBUG,
 		'newsroomAddress' => get_option( NEWSROOM_ADDRESS_OPTION_KEY ),
 		'wpSiteUrl' => site_url(),
 		'wpAdminUrl' => get_admin_url(),


### PR DESCRIPTION
- Add WP setting to set required ethereum network
- Default network if none is entered depends on `WP_DEBUG`: rinkeby if yes, mainnet if no.
- Network (and newsroom contract address) can now be set by any admin not just superadmin - we might have power users using plugin that aren't on a multisite (in which case no superadmin)
- Misc PHPCS fixes